### PR TITLE
针对login.html文件的优化

### DIFF
--- a/index_admin.html
+++ b/index_admin.html
@@ -1,17 +1,22 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Frameset//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html lang="zh-CN">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=gb2312" />
-<title>江西农业大学学生工作管理系统</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>鐢靛姏澶у瀛︾睄绠＄悊绯荤粺</title>
+    <link rel="stylesheet" href="styles.css">
 </head>
-
-<frameset rows="59,*" cols="*" frameborder="no" border="0" framespacing="0">
-  <frame src="files/top.html" name="topFrame" scrolling="No" noresize="noresize" id="topFrame" title="topFrame" />
-  <frameset cols="213,*" frameborder="no" border="0" framespacing="0">
-    <frame src="files/systemAdmin/left.html" name="leftFrame" scrolling="No" noresize="noresize" id="leftFrame" title="leftFrame" />
-    <frame src="files/systemAdmin/mainfra.html" name="mainFrame" id="mainFrame" title="mainFrame" />
-  </frameset>
-</frameset>
-<noframes><body>
+<body>
+    <header>
+        <iframe src="files/top.html" name="topFrame" id="topFrame" title="topFrame"></iframe>
+    </header>
+    <div class="container">
+        <aside>
+            <iframe src="files/systemAdmin/left.html" name="leftFrame" id="leftFrame" title="leftFrame"></iframe>
+        </aside>
+        <main>
+            <iframe src="files/systemAdmin/mainfra.html" name="mainFrame" id="mainFrame" title="mainFrame"></iframe>
+        </main>
+    </div>
 </body>
-</noframes></html>
+</html>

--- a/index_student.html
+++ b/index_student.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=gb2312" />
-<title>江西农业大学学生工作管理系统</title>
+<title>锟斤拷锟斤拷农业锟斤拷学学锟斤拷锟斤拷锟斤拷锟斤拷锟斤拷系统</title>
 </head>
 
 <frameset rows="59,*" cols="*" frameborder="no" border="0" framespacing="0">


### PR DESCRIPTION
使用现代的 HTML5 标准：HTML5 提供了更简洁的文档类型声明和更丰富的语义标签。
移除 frameset：frameset 标签已经被 HTML5 弃用，建议使用 iframe 或者现代的布局方式（如 flexbox 或 grid）。 字符编码：使用 UTF-8 编码，兼容性更好。
优化布局：使用 CSS 进行布局控制，避免使用过时的 HTML 标签.